### PR TITLE
Include gem name in warnings

### DIFF
--- a/lib/sparoid/cli.rb
+++ b/lib/sparoid/cli.rb
@@ -11,7 +11,7 @@ module Sparoid
     def auth(host, port = 8484)
       send_auth(host, port, options[:config])
     rescue Errno::ENOENT
-      abort "Config not found"
+      abort "Sparoid config not found"
     rescue StandardError => e
       abort e.message
     end
@@ -22,7 +22,7 @@ module Sparoid
       begin
         send_auth(host, spa_port, options[:config])
       rescue Errno::ENOENT
-        warn "Config not found"
+        warn "Sparoid config not found"
       end
       Sparoid.fdpass(host, port)
     rescue StandardError => e


### PR DESCRIPTION
## Description of the change

Provides more context when Sparoid is run as part of a larger system.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Seeing `Config not found` in logs can make you wonder what config wasn't found :) 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

### Deployment

- [ ] The environment (`heroku config`) has been updated with any new required `ENV` variables
