### PR TITLE
Update the cache if it doesn't contain a valid IP address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.0"
+gem "minitest-stub-const"
 gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.7"
 gem "rubocop-minitest", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in sparoid.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-
 gem "minitest", "~> 5.0"
-
+gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.7"
-
 gem "rubocop-minitest", require: false
-
 gem "rubocop-rake", require: false

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -100,6 +100,10 @@ module Sparoid
       f.flock(File::LOCK_SH)
       Resolv::IPv4.create f.read
     end
+  rescue ArgumentError => e
+    return write_cache if e.message =~ /cannot interpret as IPv4 address/
+
+    raise e
   end
 
   def write_cache

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -39,6 +39,12 @@ class SparoidTest < Minitest::Test
     end
   end
 
+  def test_it_sends_message_with_empty_cache_file
+    Sparoid.stub_const(:SPAROID_CACHE_PATH, Tempfile.new.path) do
+      assert_output(nil, "") { test_it_sends_message }
+    end
+  end
+
   def test_it_resolves_public_ip_only_once_per_instance
     dns = MiniTest::Mock.new
     dns.expect :getresource, Resolv::IPv4.create("1.1.1.1"), ["myip.opendns.com", Resolv::DNS::Resource::IN::A]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "tempfile"
+ENV["SPAROID_CACHE_PATH"] ||= Tempfile.new("sparoid_cache").path
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "sparoid"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,5 @@ ENV["SPAROID_CACHE_PATH"] ||= Tempfile.new("sparoid_cache").path
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "sparoid"
 
+require "minitest/stub_const"
 require "minitest/autorun"


### PR DESCRIPTION
## Description of the change

Happens when the cache file is empty, for instance.

Should get rid of the warnings like:

    Sparoid: #<ArgumentError: cannot interpret as IPv4 address: "">

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues


## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

### Deployment

- [ ] The environment (`heroku config`) has been updated with any new required `ENV` variables
