### PR TITLE
Allow override of public ip, open for someone else

### DIFF
--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -12,9 +12,9 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   SPAROID_CACHE_PATH = ENV.fetch("SPAROID_CACHE_PATH", "/tmp/.sparoid_public_ip")
 
   # Send an authorization packet
-  def auth(key, hmac_key, host, port, public_ip: nil)
+  def auth(key, hmac_key, host, port, open_for_ip: cached_public_ip)
     addrs = resolve_ip_addresses(host, port)
-    ip = Resolv::IPv4.create(public_ip || cached_public_ip)
+    ip = Resolv::IPv4.create(open_for_ip)
     msg = message(ip)
     data = prefix_hmac(hmac_key, encrypt(key, msg))
     sendmsg(addrs, data)

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -39,7 +39,7 @@ class SparoidTest < Minitest::Test
     end
   end
 
-  def test_it_uses_public_ip_override
+  def test_it_opens_for_passed_in_ip_argument
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
     UDPSocket.open do |server|
@@ -47,7 +47,7 @@ class SparoidTest < Minitest::Test
       port = server.addr[1]
       s = Sparoid::Instance.new
       s.stub(:public_ip, ->(*_) { raise "public_ip method not expected to be called" }) do
-        s.auth(key, hmac_key, "127.0.0.1", port, public_ip: "127.0.1.1")
+        s.auth(key, hmac_key, "127.0.0.1", port, open_for_ip: "127.0.1.1")
       end
     end
   end


### PR DESCRIPTION
Extra optional argument to `Sparoid.auth`

    Sparoid.auth(.., open_for_ip:)

Performance detail, passing an `Resolv::IPv4` object to `Resolv::IPv4.create` will just trigger early return, so it's fast. [source](https://github.com/ruby/resolv/blob/261f04905860725de3920911dafe01eb8afa97f1/lib/resolv.rb#L2360-L2376).

### WHY are these changes introduced?

Useful when `Sparoid.auth` operation isn't done on the instance that will connect, e.g. web server letting a browser accessing a host.

### WHAT is this pull request doing?

Allow override of public ip, open for someone else, by adding an extra optional argument to `Sparoid.auth`.

### HOW can this pull request be tested?

Specs will test that we use the passed in value and not try to resolve the public IP.

