### PR TITLE
Lookup public IP using HTTP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,22 @@
 name: Ruby
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.7, '3.0', 3.1, ruby-head ]
+        ruby: [ 2.7, 3.1, 3.2, 3.3, ruby-head ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: bundle install
+        bundler-cache: true
     - run: bundle exec rake


### PR DESCRIPTION
### WHY are these changes introduced?

Both OpenDNS and Google DNS has problems looking up the public IP on IPv6 connections. Lookup up using HTTP (TCP) seems more stable. The lookup time is about 110ms longer with this mechanism.

checkip.amazonaws.com for now only resolvs to IPv4 addresses. If that would change we would need to lookup the A address of the domain and connect to that IP manually. It's like 2 more lines of code only, if connect_timeout isn't needed, then it's a bit more involved.


### WHAT is this pull request doing?

Looking up the public IP using HTTP.

### HOW can this pull request be tested?

Specs

<!---

Friendly reminders

- Write documentation (Internal, API, Website)
- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
