### PR TITLE
Add IPv6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.7, 3.1, 3.2, 3.3, ruby-head ]
+        ruby: [ 3.2, 3.3, 3.4, 4.0, ruby-head ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
 
@@ -13,3 +13,6 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Metrics/MethodLength:
+  Enabled: false

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -157,6 +157,8 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     [version, ts, nounce, ip.address].pack("N q> a16 a4")
   end
 
+  # Message format can be found the server repository:
+  # https://github.com/84codes/sparoid/blob/main/src/message.cr
   def message_v2(ip, range = nil)
     version = 2
     ts = (Time.now.utc.to_f * 1000).floor

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -207,6 +207,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     File.open(SPAROID_CACHE_PATH, File::WRONLY | File::CREAT, 0o0644) do |f|
       f.flock(File::LOCK_EX)
       ips = public_ips
+      warn "Sparoid: Failed to retrieve public IPs" if ips.empty?
       f.truncate(0)
       f.rewind
       ips.each do |ip|

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -215,7 +215,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   def public_ip(port = 80) # rubocop:disable Metrics/AbcSize
     URLS.map do |host|
-      Socket.tcp(host, port, connect_timeout: 3) do |sock|
+      Socket.tcp(host, port, connect_timeout: 3, resolv_timeout: 3) do |sock|
         sock.sync = true
         sock.print "GET / HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n"
         status = sock.readline(chomp: true)

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -90,15 +90,15 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   def generate_public_ip_messages
     messages = []
-    ipv6_added = false
+    ipv6_native = false
     public_ipv6_with_range.each do |addr, prefixlen|
       ipv6 = Resolv::IPv6.create(addr)
       messages << message_v2(ipv6, prefixlen)
-      ipv6_added = true
+      ipv6_native = true
     end
 
     cached_public_ips.each do |ip|
-      next if ip.is_a?(Resolv::IPv6) && ipv6_added
+      next if ip.is_a?(Resolv::IPv6) && ipv6_native
 
       messages << create_messages(ip)
     end

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -4,6 +4,7 @@ require_relative "sparoid/version"
 require "socket"
 require "openssl"
 require "resolv"
+require "timeout"
 
 # Single Packet Authorisation client
 module Sparoid # rubocop:disable Metrics/ModuleLength
@@ -215,20 +216,22 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   def public_ip(port = 80) # rubocop:disable Metrics/AbcSize
     URLS.map do |host|
-      Socket.tcp(host, port, connect_timeout: 3, resolv_timeout: 3) do |sock|
-        sock.sync = true
-        sock.print "GET / HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n"
-        status = sock.readline(chomp: true)
-        raise(ResolvError, "#{host}:#{port} response: #{status}") unless status.start_with? "HTTP/1.1 200 "
+      Timeout.timeout(5) do
+        Socket.tcp(host, port, connect_timeout: 3, resolv_timeout: 3) do |sock|
+          sock.sync = true
+          sock.print "GET / HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n"
+          status = sock.readline(chomp: true)
+          raise(ResolvError, "#{host}:#{port} response: #{status}") unless status.start_with? "HTTP/1.1 200 "
 
-        content_length = 0
-        until (header = sock.readline(chomp: true)).empty?
-          if (m = header.match(/^Content-Length: (\d+)/))
-            content_length = m[1].to_i
+          content_length = 0
+          until (header = sock.readline(chomp: true)).empty?
+            if (m = header.match(/^Content-Length: (\d+)/))
+              content_length = m[1].to_i
+            end
           end
+          ip = sock.read(content_length).chomp
+          string_to_ip(ip)
         end
-        ip = sock.read(content_length).chomp
-        string_to_ip(ip)
       end
     rescue StandardError
       nil

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -258,7 +258,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   def public_ipv6_with_range
     global_ipv6_ifs = Socket.getifaddrs.select do |addr|
       addrinfo = addr.addr
-      addrinfo.ipv6? && global_ipv6?(addrinfo)
+      addrinfo&.ipv6? && global_ipv6?(addrinfo)
     end
 
     global_ipv6_ifs.map do |iface|

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -108,7 +108,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   def create_messages(ip)
     case ip
     when Resolv::IPv4
-      [message_v2(ip, 32), message(ip)]
+      [message(ip), message_v2(ip, 32)]
     when Resolv::IPv6
       [message_v2(ip, 128)]
     else

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -230,7 +230,9 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
         ip = sock.read(content_length).chomp
         string_to_ip(ip)
       end
-    end
+    rescue StandardError
+      nil
+    end.compact
   end
 
   def string_to_ip(ip)

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -11,20 +11,28 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   SPAROID_CACHE_PATH = ENV.fetch("SPAROID_CACHE_PATH", "/tmp/.sparoid_public_ip")
 
+  URLS = [
+    "ipv6.icanhazip.com",
+    "ipv4.icanhazip.com"
+  ].freeze
+
   # Send an authorization packet
-  def auth(key, hmac_key, host, port, open_for_ip: cached_public_ip)
+  def auth(key, hmac_key, host, port, open_for_ip: nil)
     addrs = resolve_ip_addresses(host, port)
-    ip = Resolv::IPv4.create(open_for_ip)
-    msg = message(ip)
-    data = prefix_hmac(hmac_key, encrypt(key, msg))
-    sendmsg(addrs, data)
+    addrs.each do |addr|
+      messages = generate_messages(open_for_ip)
+      data = messages.map do |message|
+        prefix_hmac(hmac_key, encrypt(key, message))
+      end
+      sendmsg(addr, data)
+    end
 
     # wait some time for the server to actually open the port
     # if we don't wait the next SYN package will be dropped
     # and it have to be redelivered, adding 1 second delay
     sleep 0.02
 
-    addrs.map(&:ip_address) # return resolved IP(s)
+    addrs
   end
 
   # Generate new aes and hmac keys, print to stdout
@@ -37,11 +45,11 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   end
 
   # Connect to a TCP server and pass the FD to the parent
-  def fdpass(ips, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize
     # try connect to all IPs
-    sockets = ips.map do |ip|
-      Socket.new(Socket::AF_INET, Socket::SOCK_STREAM).tap do |s|
-        s.connect_nonblock(Socket.sockaddr_in(port, ip), exception: false)
+    sockets = addrs.map do |addr|
+      Socket.new(addr.afamily, Socket::SOCK_STREAM).tap do |s|
+        s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
       end
     end
     # wait for any socket to be connected
@@ -51,9 +59,9 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
       writeable.each do |s|
         idx = sockets.index(s)
         sockets.delete_at(idx) # don't retry this socket again
-        ip = ips.delete_at(idx) # find the IP for the socket
+        addr = addrs.delete_at(idx) # find the IP for the socket
         begin
-          s.connect_nonblock(Socket.sockaddr_in(port, ip)) # check for errors
+          s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address)) # check for errors
         rescue Errno::EISCONN
           # already connected, continue
         rescue SystemCallError
@@ -69,11 +77,49 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   private
 
-  def sendmsg(addrs, data)
-    socket = UDPSocket.new
+  def generate_messages(ip)
+    messages = if ip
+                 create_messages(string_to_ip(ip))
+               else
+                 generate_public_ip_messages
+               end
+
+    messages.flatten.sort_by!(&:bytesize)
+  end
+
+  def generate_public_ip_messages
+    messages = []
+    ipv6_added = false
+    public_ipv6_with_range.each do |addr, prefixlen|
+      ipv6 = Resolv::IPv6.create(addr)
+      messages << message_v2(ipv6, prefixlen)
+      ipv6_added = true
+    end
+
+    cached_public_ip.each do |ip|
+      next if ip.is_a?(Resolv::IPv6) && ipv6_added
+
+      messages << create_messages(ip)
+    end
+    messages
+  end
+
+  def create_messages(ip)
+    case ip
+    when Resolv::IPv4
+      [message_v2(ip, 32), message(ip)]
+    when Resolv::IPv6
+      [message_v2(ip, 128)]
+    else
+      raise ArgumentError, "Unsupported IP type #{ip.class}"
+    end
+  end
+
+  def sendmsg(addr, data)
+    socket = UDPSocket.new(addr.afamily)
     socket.nonblock = false
-    addrs.each do |addr|
-      socket.sendmsg data, 0, addr
+    data.each do |packet|
+      socket.sendmsg packet, 0, addr
     rescue StandardError => e
       warn "Sparoid error: #{e.message}"
     end
@@ -110,6 +156,19 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     [version, ts, nounce, ip.address].pack("N q> a16 a4")
   end
 
+  def message_v2(ip, range = nil)
+    version = 2
+    ts = (Time.now.utc.to_f * 1000).floor
+    nounce = OpenSSL::Random.random_bytes(16)
+    family = case ip
+             when Resolv::IPv4 then 4
+             when Resolv::IPv6 then 6
+             else raise ArgumentError, "Unsupported IP type #{ip.class}"
+             end
+    range ||= (family == 4 ? 32 : 128)
+    [version, ts, nounce, family, ip.address, range].pack("N q> a16 C a* C")
+  end
+
   def cached_public_ip
     if up_to_date_cache?
       read_cache
@@ -131,7 +190,9 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   def read_cache
     File.open(SPAROID_CACHE_PATH, "r") do |f|
       f.flock(File::LOCK_SH)
-      Resolv::IPv4.create f.read
+      f.readlines(chomp: true).map do |line|
+        string_to_ip(line)
+      end
     end
   rescue ArgumentError => e
     return write_cache if /cannot interpret as IPv4 address/.match?(e.message)
@@ -142,38 +203,74 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   def write_cache
     File.open(SPAROID_CACHE_PATH, File::WRONLY | File::CREAT, 0o0644) do |f|
       f.flock(File::LOCK_EX)
-      ip = public_ip
+      ips = public_ip
       f.truncate(0)
-      f.write ip.to_s
-      ip
+      f.rewind
+      ips.each do |ip|
+        f.puts ip.to_s
+      end
+      ips
     end
   end
 
-  def public_ip(host = "checkip.amazonaws.com", port = 80) # rubocop:disable Metrics/MethodLength
-    Socket.tcp(host, port, connect_timeout: 3) do |sock|
-      sock.sync = true
-      sock.print "GET / HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n"
-      status = sock.readline(chomp: true)
-      raise(ResolvError, "#{host}:#{port} response: #{status}") unless status.start_with? "HTTP/1.1 200 "
+  def public_ip(port = 80) # rubocop:disable Metrics/AbcSize
+    URLS.map do |host|
+      Socket.tcp(host, port, connect_timeout: 3) do |sock|
+        sock.sync = true
+        sock.print "GET / HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n"
+        status = sock.readline(chomp: true)
+        raise(ResolvError, "#{host}:#{port} response: #{status}") unless status.start_with? "HTTP/1.1 200 "
 
-      content_length = 0
-      until (header = sock.readline(chomp: true)).empty?
-        if (m = header.match(/^Content-Length: (\d+)/))
-          content_length = m[1].to_i
+        content_length = 0
+        until (header = sock.readline(chomp: true)).empty?
+          if (m = header.match(/^Content-Length: (\d+)/))
+            content_length = m[1].to_i
+          end
         end
+        ip = sock.read(content_length).chomp
+        string_to_ip(ip)
       end
-      ip = sock.read(content_length).chomp
-      Resolv::IPv4.create ip
+    end
+  end
+
+  def string_to_ip(ip)
+    case ip
+    when Resolv::IPv4::Regex
+      Resolv::IPv4.create(ip)
+    when Resolv::IPv6::Regex
+      Resolv::IPv6.create(ip)
+    else
+      raise ArgumentError, "Unsupported IP format #{ip}"
     end
   end
 
   def resolve_ip_addresses(host, port)
-    addresses = Addrinfo.getaddrinfo(host, port, :INET, :DGRAM)
+    addresses = Addrinfo.getaddrinfo(host, port)
     raise(ResolvError, "Sparoid failed to resolv #{host}") if addresses.empty?
 
-    addresses
+    addresses.select { |addr| addr.socktype == Socket::SOCK_DGRAM }
   rescue SocketError
     raise(ResolvError, "Sparoid failed to resolv #{host}")
+  end
+
+  def public_ipv6_with_range
+    global_ipv6_ifs = Socket.getifaddrs.select do |addr|
+      addrinfo = addr.addr
+      addrinfo.ipv6? && global_ipv6?(addrinfo)
+    end
+
+    global_ipv6_ifs.map do |iface|
+      addrinfo = iface.addr
+      netmask_addr = IPAddr.new(iface.netmask.ip_address)
+      prefixlen = netmask_addr.to_i.to_s(2).count("1")
+      next addrinfo.ip_address, prefixlen
+    end
+  end
+
+  def global_ipv6?(addrinfo)
+    !(addrinfo.ipv6_mc_global? || addrinfo.ipv6_loopback? || addrinfo.ipv6_v4mapped? ||
+      addrinfo.ipv6_linklocal? || addrinfo.ipv6_multicast? || addrinfo.ipv6_sitelocal? ||
+      addrinfo.ip_address.start_with?("fd00"))
   end
 
   class Error < StandardError; end

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -97,7 +97,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
       ipv6_added = true
     end
 
-    cached_public_ip.each do |ip|
+    cached_public_ips.each do |ip|
       next if ip.is_a?(Resolv::IPv6) && ipv6_added
 
       messages << create_messages(ip)
@@ -170,7 +170,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     [version, ts, nounce, family, ip.address, range].pack("N q> a16 C a* C")
   end
 
-  def cached_public_ip
+  def cached_public_ips
     if up_to_date_cache?
       read_cache
     else
@@ -178,7 +178,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     end
   rescue StandardError => e
     warn "Sparoid: #{e.inspect}"
-    public_ip
+    public_ips
   end
 
   def up_to_date_cache?
@@ -204,7 +204,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   def write_cache
     File.open(SPAROID_CACHE_PATH, File::WRONLY | File::CREAT, 0o0644) do |f|
       f.flock(File::LOCK_EX)
-      ips = public_ip
+      ips = public_ips
       f.truncate(0)
       f.rewind
       ips.each do |ip|
@@ -214,7 +214,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def public_ip(port = 80) # rubocop:disable Metrics/AbcSize
+  def public_ips(port = 80) # rubocop:disable Metrics/AbcSize
     URLS.map do |host|
       Timeout.timeout(5) do
         Socket.tcp(host, port, connect_timeout: 3, resolv_timeout: 3) do |sock|
@@ -282,16 +282,16 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   class ResolvError < Error; end
 
-  # Instance of SPAroid that only resolved public_ip once
+  # Instance of SPAroid that only resolved public_ips once
   class Instance
     include Sparoid
 
-    def public_ip(*args)
-      @public_ip ||= super
+    def public_ips(*args)
+      @public_ips ||= super
     end
 
-    def cached_public_ip
-      public_ip
+    def cached_public_ips
+      public_ips
     end
   end
 end

--- a/lib/sparoid/cli.rb
+++ b/lib/sparoid/cli.rb
@@ -15,6 +15,7 @@ module Sparoid
     rescue Errno::ENOENT
       abort "Sparoid: Config not found"
     rescue StandardError => e
+      pp e.backtrace
       abort "Sparoid: #{e.message} (#{host})"
     end
 

--- a/sparoid.gemspec
+++ b/sparoid.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Single Packet Authorisation client"
   spec.homepage      = "https://github.com/84codes/sparoid.rb"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -8,7 +8,7 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   end
 
   def test_it_resolves_public_ip
-    addresses = Sparoid.send(:public_ip)
+    addresses = Sparoid.send(:public_ips)
     assert(addresses.any? { |ip| ip.is_a?(Resolv::IPv4) || ip.is_a?(Resolv::IPv6) })
   end
 
@@ -52,7 +52,7 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       server.bind("127.0.0.1", 0)
       port = server.addr[1]
       s = Sparoid::Instance.new
-      s.stub(:public_ip, ->(*_) { raise "public_ip method not expected to be called" }) do
+      s.stub(:public_ips, ->(*_) { raise "public_ip method not expected to be called" }) do
         s.auth(key, hmac_key, "127.0.0.1", port, open_for_ip: "127.0.1.1")
       end
     end

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class SparoidTest < Minitest::Test
+class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_that_it_has_a_version_number
     refute_nil ::Sparoid::VERSION
   end

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -38,7 +38,7 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     UDPSocket.open do |server|
       server.bind("127.0.0.1", 0)
       port = server.addr[1]
-      Sparoid.auth(key, hmac_key, "127.0.0.1", port)
+      Sparoid.auth(key, hmac_key, "127.0.0.1", port, open_for_ip: "127.0.0.1")
       msg, = server.recvfrom(512)
 
       assert_equal 96, msg.bytesize
@@ -58,14 +58,24 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def test_it_sends_message_with_prepopulated_cache_file
+  def test_it_sends_message_with_prepopulated_cache_file # rubocop:disable Metrics/AbcSize
+    key = "0000000000000000000000000000000000000000000000000000000000000000"
+    hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
     cache_file = Tempfile.new
     cache_file.write("127.0.0.1\n")
     cache_file.close
     # Touch the file to make it recent (within cache validity period)
     FileUtils.touch(cache_file.path)
     Sparoid.stub_const(:SPAROID_CACHE_PATH, cache_file.path) do
-      assert_output(nil, "") { test_it_sends_message }
+      assert_output(nil, "") do
+        UDPSocket.open do |server|
+          server.bind("127.0.0.1", 0)
+          port = server.addr[1]
+          Sparoid.auth(key, hmac_key, "127.0.0.1", port)
+          msg, = server.recvfrom(512)
+          assert_equal 96, msg.bytesize
+        end
+      end
     end
   ensure
     cache_file.unlink
@@ -114,7 +124,7 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     UDPSocket.open do |server|
       server.bind("127.0.0.1", 0)
       port = server.addr[1]
-      s.auth(key, hmac_key, "127.0.0.1", port)
+      s.auth(key, hmac_key, "127.0.0.1", port, open_for_ip: "127.0.0.1")
       msg, = server.recvfrom(512)
 
       assert_equal 96, msg.bytesize

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -8,22 +8,25 @@ class SparoidTest < Minitest::Test
   end
 
   def test_it_resolves_public_ip
-    assert_match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, Sparoid.send(:public_ip).to_s)
+    addresses = Sparoid.send(:public_ip)
+    assert(addresses.any? { |ip| ip.is_a?(Resolv::IPv4) || ip.is_a?(Resolv::IPv6) })
   end
 
   def test_it_creates_a_message
-    assert_equal 32, Sparoid.send(:message, Sparoid.send(:public_ip)).bytesize
+    ip = Resolv::IPv4.create("127.0.0.1")
+    assert_equal 32, Sparoid.send(:message, ip).bytesize
   end
 
   def test_it_encrypts_messages
     key = "0000000000000000000000000000000000000000000000000000000000000000"
-
-    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message, Sparoid.send(:public_ip))).bytesize
+    ip = Resolv::IPv4.create("127.0.0.1")
+    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message, ip)).bytesize
   end
 
   def test_it_adds_hmac
     key = "0000000000000000000000000000000000000000000000000000000000000000"
-    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message, Sparoid.send(:public_ip)))
+    ip = Resolv::IPv4.create("127.0.0.1")
+    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message, ip))
     hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
 
     assert_equal 96, Sparoid.send(:prefix_hmac, hmac_key, msg).bytesize
@@ -55,36 +58,40 @@ class SparoidTest < Minitest::Test
     end
   end
 
-  def test_it_sends_message_with_empty_cache_file
-    Sparoid.stub_const(:SPAROID_CACHE_PATH, Tempfile.new.path) do
+  def test_it_sends_message_with_prepopulated_cache_file
+    cache_file = Tempfile.new
+    cache_file.write("127.0.0.1\n")
+    cache_file.close
+    # Touch the file to make it recent (within cache validity period)
+    FileUtils.touch(cache_file.path)
+    Sparoid.stub_const(:SPAROID_CACHE_PATH, cache_file.path) do
       assert_output(nil, "") { test_it_sends_message }
     end
+  ensure
+    cache_file.unlink
   end
 
-  def test_it_resolves_public_ip_only_once_per_instance # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    server = TCPServer.new "127.0.0.1", 0
-    host = server.addr[3]
-    port = server.addr[1]
-    Thread.new do
-      client = server.accept
-      client_ip = client.addr[3]
-      assert_equal "GET / HTTP/1.1", client.readline(chomp: true)
-      assert_match "Host: ", client.readline(chomp: true)
-      assert_equal "Connection: close", client.readline(chomp: true)
-
-      client.print "HTTP/1.1 200 OK\r\n"
-      client.print "Content-Length: #{client_ip.bytesize}\r\n"
-      client.print "\r\n"
-      client.print client_ip
-      client.close
-      server.close
-    end
-
+  def test_it_resolves_public_ip_only_once_per_instance
     s = Sparoid::Instance.new
-    2.times do
-      ip = s.public_ip host, port
-      assert_equal Resolv::IPv4.create("127.0.0.1"), ip
+    call_count = 0
+    mock_ips = [Resolv::IPv4.create("203.0.113.1"), Resolv::IPv6.create("2001:db8::1")]
+
+    # Define a method on the singleton class that tracks calls
+    s.define_singleton_method(:fetch_public_ip) do
+      call_count += 1
+      mock_ips
     end
+
+    # Override public_ip to use our tracking method
+    s.define_singleton_method(:public_ip) do |*_args|
+      @public_ip ||= fetch_public_ip
+    end
+
+    2.times do
+      ips = s.public_ip
+      assert_equal mock_ips, ips
+    end
+    assert_equal 1, call_count, "public_ip should only resolve once"
   end
 
   def test_it_raises_resolve_error_on_dns_socket_error
@@ -112,5 +119,77 @@ class SparoidTest < Minitest::Test
 
       assert_equal 96, msg.bytesize
     end
+  end
+
+  def test_message_v2_ipv4
+    ip = Resolv::IPv4.create("192.168.1.1")
+    msg = Sparoid.send(:message_v2, ip, 24)
+    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) + range(1) = 34
+    assert_equal 34, msg.bytesize
+  end
+
+  def test_message_v2_ipv6
+    ip = Resolv::IPv6.create("2001:db8::1")
+    msg = Sparoid.send(:message_v2, ip, 64)
+    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) + range(1) = 46
+    assert_equal 46, msg.bytesize
+  end
+
+  def test_string_to_ip_ipv4
+    ip = Sparoid.send(:string_to_ip, "192.168.1.1")
+    assert_instance_of Resolv::IPv4, ip
+    assert_equal "192.168.1.1", ip.to_s
+  end
+
+  def test_string_to_ip_ipv6
+    ip = Sparoid.send(:string_to_ip, "2001:db8::1")
+    assert_instance_of Resolv::IPv6, ip
+  end
+
+  def test_string_to_ip_invalid
+    assert_raises(ArgumentError) do
+      Sparoid.send(:string_to_ip, "not-an-ip")
+    end
+  end
+
+  def test_create_messages_ipv4_returns_two_messages
+    ip = Resolv::IPv4.create("127.0.0.1")
+    messages = Sparoid.send(:create_messages, ip)
+    # IPv4 returns both v2 and v1 message formats
+    assert_equal 2, messages.size
+  end
+
+  def test_generate_messages_v1_message_first
+    # v1 message (32 bytes) should come before v2 message (34 bytes) for backward compatibility
+    messages = Sparoid.send(:generate_messages, "127.0.0.1")
+    assert_equal 32, messages[0].bytesize
+    assert_equal 34, messages[1].bytesize
+  end
+
+  def test_create_messages_ipv6_returns_one_message
+    ip = Resolv::IPv6.create("::1")
+    messages = Sparoid.send(:create_messages, ip)
+    # IPv6 only returns v2 message format
+    assert_equal 1, messages.size
+  end
+
+  def test_encrypt_raises_on_invalid_key_length
+    short_key = "0000"
+    assert_raises(ArgumentError) do
+      Sparoid.send(:encrypt, short_key, "test data")
+    end
+  end
+
+  def test_prefix_hmac_raises_on_invalid_key_length
+    short_key = "0000"
+    assert_raises(ArgumentError) do
+      Sparoid.send(:prefix_hmac, short_key, "test data")
+    end
+  end
+
+  def test_keygen_outputs_keys
+    output = capture_io { Sparoid.keygen }.first
+    assert_match(/^key = [0-9a-f]{64}$/, output.lines[0].chomp)
+    assert_match(/^hmac-key = [0-9a-f]{64}$/, output.lines[1].chomp)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tempfile"
+require "fileutils"
 ENV["SPAROID_CACHE_PATH"] ||= Tempfile.new("sparoid_cache").path
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)


### PR DESCRIPTION
### WHY are these changes introduced?

Ipv6 support

### WHAT is this pull request doing?

Implements MessageV2 format for IPv6.

### HOW was this pull request tested?

Specs and manuallly by sending auth requests to server with v1 and v2 support https://github.com/84codes/sparoid/pull/17

<!---

Friendly reminders

- Write documentation (Internal, API, Website)
- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
