### PR TITLE
Remove message v2 format

### DIFF
--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -245,7 +245,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   def global_ipv6?(addr)
     !(addr.ipv6_loopback? || addr.ipv6_linklocal? || addr.ipv6_unspecified? ||
       addr.ipv6_sitelocal? || addr.ipv6_multicast? || addr.ipv6_v4mapped? ||
-      addr.ip_address.start_with?("fd"))
+      addr.ip_address.start_with?("fd", "fc"))
   end
 
   class Error < StandardError; end

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -17,6 +17,8 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     "ipv4.icanhazip.com"
   ].freeze
 
+  GOOGLE_DNS_V6 = ["2001:4860:4860::8888", 53].freeze
+
   # Send an authorization packet
   def auth(key, hmac_key, host, port, open_for_ip: nil)
     addrs = resolve_ip_addresses(host, port)
@@ -79,35 +81,16 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   private
 
   def generate_messages(ip)
-    messages = if ip
-                 [create_message(string_to_ip(ip))]
-               else
-                 generate_public_ip_messages
-               end
-
-    messages.sort_by!(&:bytesize)
-  end
-
-  def generate_public_ip_messages
-    messages = []
-    native_ipv6 = public_ipv6_by_udp
-
-    cached_public_ips.each do |ip|
-      next if ip.is_a?(Resolv::IPv6) && native_ipv6
-
-      messages << create_message(ip)
-    end
-
-    messages << create_message(Resolv::IPv6.create(native_ipv6)) if native_ipv6
-    messages
-  end
-
-  def create_message(ip)
-    case ip
-    when Resolv::IPv4, Resolv::IPv6
-      message_v2(ip)
+    if ip
+      [message(string_to_ip(ip))]
     else
-      raise ArgumentError, "Unsupported IP type #{ip.class}"
+      ips = cached_public_ips
+      native_ipv6 = public_ipv6_by_udp
+      if native_ipv6
+        ips = ips.reject { |i| i.is_a?(Resolv::IPv6) }
+        ips << Resolv::IPv6.create(native_ipv6)
+      end
+      ips.map { |i| message(i) }
     end
   end
 
@@ -145,18 +128,13 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     hmac + data
   end
 
-  # Message format can be found the server repository:
+  # Message format: version(4) + timestamp(8) + nonce(16) + ip(4 or 16)
   # https://github.com/84codes/sparoid/blob/main/src/message.cr
-  def message_v2(ip)
-    version = 2
+  def message(ip)
+    version = 1
     ts = (Time.now.utc.to_f * 1000).floor
     nounce = OpenSSL::Random.random_bytes(16)
-    family = case ip
-             when Resolv::IPv4 then 4
-             when Resolv::IPv6 then 6
-             else raise ArgumentError, "Unsupported IP type #{ip.class}"
-             end
-    [version, ts, nounce, family, ip.address].pack("N q> a16 C a*")
+    [version, ts, nounce, ip.address].pack("N q> a16 a*")
   end
 
   def cached_public_ips
@@ -248,8 +226,6 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     raise(ResolvError, "Sparoid failed to resolv #{host}")
   end
 
-  GOOGLE_DNS_V6 = ["2001:4860:4860::8888", 53].freeze
-
   # Get the public IPv6 address by asking the OS which source address
   # it would use to reach a well-known IPv6 destination.
   # Returns nil if no global IPv6 address is available.
@@ -257,13 +233,19 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     socket = UDPSocket.new(Socket::AF_INET6)
     socket.connect(*GOOGLE_DNS_V6)
     addr = socket.local_address
-    return nil if addr.ipv6_loopback? || addr.ipv6_linklocal? || addr.ip_address == "::"
+    return addr.ip_address if global_ipv6?(addr)
 
-    addr.ip_address
+    nil
   rescue StandardError
     nil
   ensure
     socket&.close
+  end
+
+  def global_ipv6?(addr)
+    !(addr.ipv6_loopback? || addr.ipv6_linklocal? || addr.ipv6_unspecified? ||
+      addr.ipv6_sitelocal? || addr.ipv6_multicast? || addr.ipv6_v4mapped? ||
+      addr.ip_address.start_with?("fd"))
   end
 
   class Error < StandardError; end

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -90,27 +90,22 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   def generate_public_ip_messages
     messages = []
-    ipv6_native = false
-    public_ipv6_with_range.each do |addr, prefixlen|
-      ipv6 = Resolv::IPv6.create(addr)
-      messages << message_v2(ipv6, prefixlen)
-      ipv6_native = true
-    end
+    native_ipv6 = public_ipv6_by_udp
 
     cached_public_ips.each do |ip|
-      next if ip.is_a?(Resolv::IPv6) && ipv6_native
+      next if ip.is_a?(Resolv::IPv6) && native_ipv6
 
       messages << create_message(ip)
     end
+
+    messages << create_message(Resolv::IPv6.create(native_ipv6)) if native_ipv6
     messages
   end
 
   def create_message(ip)
     case ip
-    when Resolv::IPv4
-      message_v2(ip, 32)
-    when Resolv::IPv6
-      message_v2(ip, 128)
+    when Resolv::IPv4, Resolv::IPv6
+      message_v2(ip)
     else
       raise ArgumentError, "Unsupported IP type #{ip.class}"
     end
@@ -152,7 +147,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   # Message format can be found the server repository:
   # https://github.com/84codes/sparoid/blob/main/src/message.cr
-  def message_v2(ip, range = nil)
+  def message_v2(ip)
     version = 2
     ts = (Time.now.utc.to_f * 1000).floor
     nounce = OpenSSL::Random.random_bytes(16)
@@ -161,8 +156,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
              when Resolv::IPv6 then 6
              else raise ArgumentError, "Unsupported IP type #{ip.class}"
              end
-    range ||= (family == 4 ? 32 : 128)
-    [version, ts, nounce, family, ip.address, range].pack("N q> a16 C a* C")
+    [version, ts, nounce, family, ip.address].pack("N q> a16 C a*")
   end
 
   def cached_public_ips
@@ -254,24 +248,22 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     raise(ResolvError, "Sparoid failed to resolv #{host}")
   end
 
-  def public_ipv6_with_range
-    global_ipv6_ifs = Socket.getifaddrs.select do |addr|
-      addrinfo = addr.addr
-      addrinfo&.ipv6? && global_ipv6?(addrinfo)
-    end
+  GOOGLE_DNS_V6 = ["2001:4860:4860::8888", 53].freeze
 
-    global_ipv6_ifs.map do |iface|
-      addrinfo = iface.addr
-      netmask_addr = IPAddr.new(iface.netmask.ip_address)
-      prefixlen = netmask_addr.to_i.to_s(2).count("1")
-      next addrinfo.ip_address, prefixlen
-    end
-  end
+  # Get the public IPv6 address by asking the OS which source address
+  # it would use to reach a well-known IPv6 destination.
+  # Returns nil if no global IPv6 address is available.
+  def public_ipv6_by_udp
+    socket = UDPSocket.new(Socket::AF_INET6)
+    socket.connect(*GOOGLE_DNS_V6)
+    addr = socket.local_address
+    return nil if addr.ipv6_loopback? || addr.ipv6_linklocal? || addr.ip_address == "::"
 
-  def global_ipv6?(addrinfo)
-    !(addrinfo.ipv6_mc_global? || addrinfo.ipv6_loopback? || addrinfo.ipv6_v4mapped? ||
-      addrinfo.ipv6_linklocal? || addrinfo.ipv6_multicast? || addrinfo.ipv6_sitelocal? ||
-      addrinfo.ip_address.start_with?("fd00"))
+    addr.ip_address
+  rescue StandardError
+    nil
+  ensure
+    socket&.close
   end
 
   class Error < StandardError; end

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -87,7 +87,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
       ips = cached_public_ips
       native_ipv6 = public_ipv6_by_udp
       if native_ipv6
-        ips = ips.reject { |i| i.is_a?(Resolv::IPv6) }
+        ips = ips.grep_v(Resolv::IPv6)
         ips << Resolv::IPv6.create(native_ipv6)
       end
       ips.map { |i| message(i) }

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -80,12 +80,12 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   def generate_messages(ip)
     messages = if ip
-                 create_messages(string_to_ip(ip))
+                 [create_message(string_to_ip(ip))]
                else
                  generate_public_ip_messages
                end
 
-    messages.flatten.sort_by!(&:bytesize)
+    messages.sort_by!(&:bytesize)
   end
 
   def generate_public_ip_messages
@@ -100,17 +100,17 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
     cached_public_ips.each do |ip|
       next if ip.is_a?(Resolv::IPv6) && ipv6_native
 
-      messages << create_messages(ip)
+      messages << create_message(ip)
     end
     messages
   end
 
-  def create_messages(ip)
+  def create_message(ip)
     case ip
     when Resolv::IPv4
-      [message(ip), message_v2(ip, 32)]
+      message_v2(ip, 32)
     when Resolv::IPv6
-      [message_v2(ip, 128)]
+      message_v2(ip, 128)
     else
       raise ArgumentError, "Unsupported IP type #{ip.class}"
     end
@@ -148,13 +148,6 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
     hmac = OpenSSL::HMAC.digest("SHA256", hmac_key, data)
     hmac + data
-  end
-
-  def message(ip)
-    version = 1
-    ts = (Time.now.utc.to_f * 1000).floor
-    nounce = OpenSSL::Random.random_bytes(16)
-    [version, ts, nounce, ip.address].pack("N q> a16 a4")
   end
 
   # Message format can be found the server repository:

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -15,13 +15,13 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_it_encrypts_messages
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     ip = Resolv::IPv4.create("127.0.0.1")
-    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip)).bytesize
+    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message, ip)).bytesize
   end
 
   def test_it_adds_hmac
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     ip = Resolv::IPv4.create("127.0.0.1")
-    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip))
+    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message, ip))
     hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
 
     assert_equal 96, Sparoid.send(:prefix_hmac, hmac_key, msg).bytesize
@@ -126,18 +126,18 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def test_message_v2_ipv4
+  def test_message_ipv4
     ip = Resolv::IPv4.create("192.168.1.1")
-    msg = Sparoid.send(:message_v2, ip)
-    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) = 33
-    assert_equal 33, msg.bytesize
+    msg = Sparoid.send(:message, ip)
+    # version(4) + timestamp(8) + nonce(16) + ip(4) = 32
+    assert_equal 32, msg.bytesize
   end
 
-  def test_message_v2_ipv6
+  def test_message_ipv6
     ip = Resolv::IPv6.create("2001:db8::1")
-    msg = Sparoid.send(:message_v2, ip)
-    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) = 45
-    assert_equal 45, msg.bytesize
+    msg = Sparoid.send(:message, ip)
+    # version(4) + timestamp(8) + nonce(16) + ip(16) = 44
+    assert_equal 44, msg.bytesize
   end
 
   def test_string_to_ip_ipv4
@@ -157,18 +157,16 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def test_create_message_ipv4
-    ip = Resolv::IPv4.create("127.0.0.1")
-    msg = Sparoid.send(:create_message, ip)
-    # v2 IPv4: version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) = 33
-    assert_equal 33, msg.bytesize
+  def test_generate_messages_ipv4
+    msgs = Sparoid.send(:generate_messages, "127.0.0.1")
+    # version(4) + timestamp(8) + nonce(16) + ip(4) = 32
+    assert_equal 32, msgs.first.bytesize
   end
 
-  def test_create_message_ipv6
-    ip = Resolv::IPv6.create("::1")
-    msg = Sparoid.send(:create_message, ip)
-    # v2 IPv6: version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) = 45
-    assert_equal 45, msg.bytesize
+  def test_generate_messages_ipv6
+    msgs = Sparoid.send(:generate_messages, "::1")
+    # version(4) + timestamp(8) + nonce(16) + ip(16) = 44
+    assert_equal 44, msgs.first.bytesize
   end
 
   def test_encrypt_raises_on_invalid_key_length

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -15,13 +15,13 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_it_encrypts_messages
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     ip = Resolv::IPv4.create("127.0.0.1")
-    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip, 32)).bytesize
+    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip)).bytesize
   end
 
   def test_it_adds_hmac
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     ip = Resolv::IPv4.create("127.0.0.1")
-    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip, 32))
+    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip))
     hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
 
     assert_equal 96, Sparoid.send(:prefix_hmac, hmac_key, msg).bytesize
@@ -128,16 +128,16 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
 
   def test_message_v2_ipv4
     ip = Resolv::IPv4.create("192.168.1.1")
-    msg = Sparoid.send(:message_v2, ip, 24)
-    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) + range(1) = 34
-    assert_equal 34, msg.bytesize
+    msg = Sparoid.send(:message_v2, ip)
+    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) = 33
+    assert_equal 33, msg.bytesize
   end
 
   def test_message_v2_ipv6
     ip = Resolv::IPv6.create("2001:db8::1")
-    msg = Sparoid.send(:message_v2, ip, 64)
-    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) + range(1) = 46
-    assert_equal 46, msg.bytesize
+    msg = Sparoid.send(:message_v2, ip)
+    # version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) = 45
+    assert_equal 45, msg.bytesize
   end
 
   def test_string_to_ip_ipv4
@@ -160,15 +160,15 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_create_message_ipv4
     ip = Resolv::IPv4.create("127.0.0.1")
     msg = Sparoid.send(:create_message, ip)
-    # v2 IPv4: version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) + range(1) = 34
-    assert_equal 34, msg.bytesize
+    # v2 IPv4: version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) = 33
+    assert_equal 33, msg.bytesize
   end
 
   def test_create_message_ipv6
     ip = Resolv::IPv6.create("::1")
     msg = Sparoid.send(:create_message, ip)
-    # v2 IPv6: version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) + range(1) = 46
-    assert_equal 46, msg.bytesize
+    # v2 IPv6: version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) = 45
+    assert_equal 45, msg.bytesize
   end
 
   def test_encrypt_raises_on_invalid_key_length

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -12,21 +12,16 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert(addresses.any? { |ip| ip.is_a?(Resolv::IPv4) || ip.is_a?(Resolv::IPv6) })
   end
 
-  def test_it_creates_a_message
-    ip = Resolv::IPv4.create("127.0.0.1")
-    assert_equal 32, Sparoid.send(:message, ip).bytesize
-  end
-
   def test_it_encrypts_messages
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     ip = Resolv::IPv4.create("127.0.0.1")
-    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message, ip)).bytesize
+    assert_equal 64, Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip, 32)).bytesize
   end
 
   def test_it_adds_hmac
     key = "0000000000000000000000000000000000000000000000000000000000000000"
     ip = Resolv::IPv4.create("127.0.0.1")
-    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message, ip))
+    msg = Sparoid.send(:encrypt, key, Sparoid.send(:message_v2, ip, 32))
     hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
 
     assert_equal 96, Sparoid.send(:prefix_hmac, hmac_key, msg).bytesize
@@ -162,25 +157,18 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def test_create_messages_ipv4_returns_two_messages
+  def test_create_message_ipv4
     ip = Resolv::IPv4.create("127.0.0.1")
-    messages = Sparoid.send(:create_messages, ip)
-    # IPv4 returns both v2 and v1 message formats
-    assert_equal 2, messages.size
+    msg = Sparoid.send(:create_message, ip)
+    # v2 IPv4: version(4) + timestamp(8) + nonce(16) + family(1) + ip(4) + range(1) = 34
+    assert_equal 34, msg.bytesize
   end
 
-  def test_generate_messages_v1_message_first
-    # v1 message (32 bytes) should come before v2 message (34 bytes) for backward compatibility
-    messages = Sparoid.send(:generate_messages, "127.0.0.1")
-    assert_equal 32, messages[0].bytesize
-    assert_equal 34, messages[1].bytesize
-  end
-
-  def test_create_messages_ipv6_returns_one_message
+  def test_create_message_ipv6
     ip = Resolv::IPv6.create("::1")
-    messages = Sparoid.send(:create_messages, ip)
-    # IPv6 only returns v2 message format
-    assert_equal 1, messages.size
+    msg = Sparoid.send(:create_message, ip)
+    # v2 IPv6: version(4) + timestamp(8) + nonce(16) + family(1) + ip(16) + range(1) = 46
+    assert_equal 46, msg.bytesize
   end
 
   def test_encrypt_raises_on_invalid_key_length


### PR DESCRIPTION
### WHY are these changes introduced?
The server software was simplified to allow message v1 format to have a IP of 16 bytes. Which means that we can simplify the ruby client by removing that message version and revert back to v1 and include the ipv6 address in that format.

### WHAT is this pull request doing?

### HOW was this pull request tested?

Specs and ran manually towards a server with sparoid server 2.0.0

<!---

Friendly reminders

- Write documentation (Internal, API, Website)
- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
