### PR TITLE
Skip addrs that fail synchronous connect in fdpass

### DIFF
--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -48,13 +48,22 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   end
 
   # Connect to a TCP server and pass the FD to the parent
-  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize
-    # try connect to all IPs
-    sockets = addrs.map do |addr|
-      Socket.new(addr.afamily, Socket::SOCK_STREAM).tap do |s|
-        s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
-      end
+  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    # Start a non-blocking connect for each addr; drop any that fail synchronously
+    # (e.g. EHOSTUNREACH when there's no route to a v6 addr) so the remaining
+    # addrs can still race in the IO.select below.
+    sockets = []
+    viable_addrs = []
+    addrs.each do |addr|
+      s = Socket.new(addr.afamily, Socket::SOCK_STREAM)
+      s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
+      sockets << s
+      viable_addrs << addr
+    rescue SystemCallError => e
+      warn "Sparoid: skip #{addr.ip_address}: #{e.message}"
+      s&.close
     end
+    addrs = viable_addrs
     # wait for any socket to be connected
     until sockets.empty?
       _, writeable, errors = IO.select(nil, sockets, nil, connect_timeout) || break

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -49,14 +49,13 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   # Connect to a TCP server and pass the FD to the parent
   def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
-    # try connect to all IPs; drop addrs that fail synchronously (e.g. no route)
-    sockets = []
-    addrs = addrs.filter_map do |addr|
+    # try connect to all IPs; skip addrs that fail synchronously (e.g. no route)
+    viable_addrs = []
+    sockets = addrs.filter_map do |addr|
       Socket.new(addr.afamily, Socket::SOCK_STREAM).tap do |s|
         s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
-        sockets << s
+        viable_addrs << addr
       end
-      addr
     rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNREFUSED => e
       warn "Sparoid: skip #{addr.ip_address}: #{e.message}"
       nil
@@ -68,7 +67,7 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
       writeable.each do |s|
         idx = sockets.index(s)
         sockets.delete_at(idx) # don't retry this socket again
-        addr = addrs.delete_at(idx) # find the IP for the socket
+        addr = viable_addrs.delete_at(idx) # find the IP for the socket
         begin
           s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address)) # check for errors
         rescue Errno::EISCONN

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -48,16 +48,17 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   end
 
   # Connect to a TCP server and pass the FD to the parent
-  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     # try connect to all IPs; skip addrs that fail synchronously (e.g. no route)
     viable_addrs = []
     sockets = addrs.filter_map do |addr|
-      Socket.new(addr.afamily, Socket::SOCK_STREAM).tap do |s|
-        s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
-        viable_addrs << addr
-      end
+      s = Socket.new(addr.afamily, Socket::SOCK_STREAM)
+      s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
+      viable_addrs << addr
+      s
     rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNREFUSED => e
       warn "Sparoid: skip #{addr.ip_address}: #{e.message}"
+      s&.close
       nil
     end
     # wait for any socket to be connected

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -48,22 +48,19 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
   end
 
   # Connect to a TCP server and pass the FD to the parent
-  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-    # Start a non-blocking connect for each addr; drop any that fail synchronously
-    # (e.g. EHOSTUNREACH when there's no route to a v6 addr) so the remaining
-    # addrs can still race in the IO.select below.
+  def fdpass(addrs, port, connect_timeout: 10) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+    # try connect to all IPs; drop addrs that fail synchronously (e.g. no route)
     sockets = []
-    viable_addrs = []
-    addrs.each do |addr|
-      s = Socket.new(addr.afamily, Socket::SOCK_STREAM)
-      s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
-      sockets << s
-      viable_addrs << addr
-    rescue SystemCallError => e
+    addrs = addrs.filter_map do |addr|
+      Socket.new(addr.afamily, Socket::SOCK_STREAM).tap do |s|
+        s.connect_nonblock(Socket.sockaddr_in(port, addr.ip_address), exception: false)
+        sockets << s
+      end
+      addr
+    rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNREFUSED => e
       warn "Sparoid: skip #{addr.ip_address}: #{e.message}"
-      s&.close
+      nil
     end
-    addrs = viable_addrs
     # wait for any socket to be connected
     until sockets.empty?
       _, writeable, errors = IO.select(nil, sockets, nil, connect_timeout) || break

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -188,4 +188,21 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert_match(/^key = [0-9a-f]{64}$/, output.lines[0].chomp)
     assert_match(/^hmac-key = [0-9a-f]{64}$/, output.lines[1].chomp)
   end
+
+  def test_fdpass_closes_socket_when_connect_fails_synchronously
+    addr = Addrinfo.tcp("127.0.0.1", 0)
+    closed = false
+    fake = Object.new
+    fake.define_singleton_method(:connect_nonblock) { |_sa, **_| raise Errno::EHOSTUNREACH }
+    fake.define_singleton_method(:close) { closed = true }
+
+    _out, err = capture_io do
+      Socket.stub(:new, fake) do
+        assert_raises(SystemExit) { Sparoid.fdpass([addr], 1) }
+      end
+    end
+
+    assert closed, "socket should be closed after synchronous connect failure"
+    assert_match(/Sparoid: skip 127\.0\.0\.1/, err)
+  end
 end


### PR DESCRIPTION
## Summary
- `connect_nonblock(..., exception: false)` only suppresses `EINPROGRESS` / `WaitWritable`. Synchronous errors like `EHOSTUNREACH` (e.g. a v6 addr with no route) still raise, escape the `addrs.map`, and kill sparoid before `IO.select` gets to race the remaining addrs.
- Caught in the wild: when a host has both A and AAAA records but the client has no v6 route, sparoid exits with `Sparoid error: No route to host - connect(2)` and SSH reports `proxy dialer did not pass back a connection` — even though v4 would have worked.
- Fix: rescue `SystemCallError` around the initial `connect_nonblock`, `warn`, and drop the addr. The surviving sockets still race via `IO.select`, so v4 wins in the mixed-family case.

## Test plan
- [ ] `bundle exec rake test` — all existing tests pass
- [ ] `bundle exec rubocop` — clean
- [x] Manual: point a machines worker at a broker whose AAAA record resolves to an unreachable v6 addr; confirm SSH connects via v4 and `Sparoid: skip <addr>: No route to host` is warned (instead of sparoid dying)