### PR TITLE
Release 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.1.2] - 2026-04-30
+
+- Skip addresses that fail synchronous connect in fdpass (#20)
+
+## [2.1.1] - 2026-04-13
+
+- Remove the usage of Timeout (#19)
+
 ## [2.1.0] - 2026-03-10
 
 - Aligning CLI with Crystal client interface (`send`/`connect` subcommands with flags)

--- a/lib/sparoid/version.rb
+++ b/lib/sparoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sparoid
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
## Summary
- Bump version to 2.1.2
- CHANGELOG entry for #20 (skip addrs that fail synchronous connect in fdpass)
- Backfill missing CHANGELOG entry for 2.1.1 (Timeout removal, #19)

## Test plan
- [x] `bundle exec rake` (tests + rubocop) passes locally