### PR TITLE
Add OIDC-based release workflow on tag push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         ruby: [ 3.2, 3.3, 3.4, 4.0, ruby-head ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
         ruby: [ 3.2, 3.3, 3.4, 4.0, ruby-head ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - run: bundle exec rake
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ Host *.example.com
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To build the gem locally, run `gem build sparoid.gemspec`.
+
+To release a new version:
+
+1. Bump `Sparoid::VERSION` in `lib/sparoid/version.rb` and add an entry to `CHANGELOG.md`.
+2. Open a PR with the bump, get it merged into `main`.
+3. Push a tag matching the new version, e.g. `git tag v2.1.2 && git push origin v2.1.2`.
+
+The `Release` GitHub Actions workflow then builds the gem and publishes it to [rubygems.org](https://rubygems.org) via OIDC trusted publishing — no API key required.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Host *.example.com
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To build the gem locally, run `gem build sparoid.gemspec`.
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 To release a new version:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes
- Uses `rubygems/release-gem@v1` which performs OIDC token exchange with rubygems.org, builds the gem, and pushes it — no API key in repo secrets
- Replaces the local `rake release` flow once the rubygems.org trusted-publisher config is in place

## Manual setup required before this works
- [ ] On rubygems.org → `sparoid` gem → **Trusted publishers** → Add GitHub Actions publisher with:
  - Owner: `84codes`
  - Repository: `sparoid.rb`
  - Workflow filename: `release.yml`
  - Environment: *(leave blank unless we add one)*
- [ ] Disable MFA-on-push for the gem, OR keep it — trusted publishing satisfies the MFA requirement automatically

## Test plan
- [ ] After merge + trusted-publisher config: push a `v2.1.2` tag and confirm the workflow publishes to rubygems.org