### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.2.0] - 2026-05-06
+
+- Raise when sendmsg fails for every resolved address (#23)
+
 ## [2.1.2] - 2026-04-30
 
 - Skip addresses that fail synchronous connect in fdpass (#20)

--- a/lib/sparoid/version.rb
+++ b/lib/sparoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sparoid
-  VERSION = "2.1.2"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
## Summary
- Bump version to 2.2.0
- CHANGELOG entry for #23 (raise when sendmsg fails for every resolved address)

Minor bump rather than patch: `auth` now raises `Sparoid::Error` when every address fails, and returns only the subset of successful addresses — both observable contract changes for callers.

## Test plan
- [x] `bundle exec rubocop` (clean)
- [x] `bundle exec rake test` (23 runs, 42 assertions, 0 failures)