### PR TITLE
Make Sparoid::Instance public-IP resolution thread-safe and self-healing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.7"
 gem "rubocop-minitest", require: false
 gem "rubocop-rake", require: false
+gem "webmock"

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -263,13 +263,14 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
     def initialize
       @resolve_mutex = Mutex.new
+      @public_ips = []
     end
 
     def cached_public_ips
-      return @public_ips if @public_ips&.any?
+      return @public_ips if @public_ips.any?
 
       @resolve_mutex.synchronize do
-        return @public_ips if @public_ips&.any?
+        return @public_ips if @public_ips.any?
 
         ips = public_ips
         if ips.empty?

--- a/lib/sparoid.rb
+++ b/lib/sparoid.rb
@@ -103,6 +103,8 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
         ips = ips.grep_v(Resolv::IPv6)
         ips << Resolv::IPv6.create(native_ipv6)
       end
+      raise PublicIPError, "Sparoid could not resolve a public IP to knock from" if ips.empty?
+
       ips.map { |i| message(i) }
     end
   end
@@ -253,16 +255,30 @@ module Sparoid # rubocop:disable Metrics/ModuleLength
 
   class ResolvError < Error; end
 
-  # Instance of SPAroid that only resolved public_ips once
+  class PublicIPError < Error; end
+
+  # Instance of SPAroid that resolves its public IP once and reuses it
   class Instance
     include Sparoid
 
-    def public_ips(*args)
-      @public_ips ||= super
+    def initialize
+      @resolve_mutex = Mutex.new
     end
 
     def cached_public_ips
-      public_ips
+      return @public_ips if @public_ips&.any?
+
+      @resolve_mutex.synchronize do
+        return @public_ips if @public_ips&.any?
+
+        ips = public_ips
+        if ips.empty?
+          warn "Sparoid: Failed to retrieve public IPs"
+        else
+          @public_ips = ips
+        end
+        ips
+      end
     end
   end
 end

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -228,6 +228,38 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert_match(/^hmac-key = [0-9a-f]{64}$/, output.lines[1].chomp)
   end
 
+  def stub_icanhazip(ipv4_body:, ipv6_body: "")
+    stub_request(:get, "http://ipv6.icanhazip.com/").to_return(status: 200, body: ipv6_body)
+    stub_request(:get, "http://ipv4.icanhazip.com/").to_return(status: 200, body: ipv4_body)
+  end
+
+  def test_instance_retries_and_recovers_instead_of_pinning_empty
+    instance = Sparoid::Instance.new
+
+    stub_icanhazip(ipv4_body: "", ipv6_body: "")
+    _out, err = capture_io { assert_empty instance.cached_public_ips }
+    assert_match(/Failed to retrieve public IPs/, err)
+    assert_nil instance.instance_variable_get(:@public_ips), "empty result must not be memoized"
+
+    stub_icanhazip(ipv4_body: "203.0.113.7\n")
+    assert_equal ["203.0.113.7"], instance.cached_public_ips.map(&:to_s)
+  end
+
+  def test_auth_raises_when_no_public_ip_resolved
+    key = "0000000000000000000000000000000000000000000000000000000000000000"
+    hmac_key = "0000000000000000000000000000000000000000000000000000000000000000"
+    s = Sparoid::Instance.new
+
+    s.stub(:cached_public_ips, []) do
+      s.stub(:public_ipv6_by_udp, nil) do
+        err = assert_raises(Sparoid::PublicIPError) do
+          s.auth(key, hmac_key, "127.0.0.1", 1337)
+        end
+        assert_match(/could not resolve a public IP/, err.message)
+      end
+    end
+  end
+
   def test_fdpass_closes_socket_when_connect_fails_synchronously
     addr = Addrinfo.tcp("127.0.0.1", 0)
     closed = false

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -240,7 +240,7 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     stub_icanhazip(ipv4_body: "", ipv6_body: "")
     _out, err = capture_io { assert_empty instance.cached_public_ips }
     assert_match(/Failed to retrieve public IPs/, err)
-    assert_nil instance.instance_variable_get(:@public_ips), "empty result must not be memoized"
+    assert_empty instance.instance_variable_get(:@public_ips), "empty result must not be memoized"
 
     stub_icanhazip(ipv4_body: "203.0.113.7\n")
     assert_equal ["203.0.113.7"], instance.cached_public_ips.map(&:to_s)

--- a/test/sparoid_test.rb
+++ b/test/sparoid_test.rb
@@ -8,6 +8,7 @@ class SparoidTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   end
 
   def test_it_resolves_public_ip
+    stub_icanhazip(ipv4_body: "203.0.113.7\n", ipv6_body: "2001:db8::1\n")
     addresses = Sparoid.send(:public_ips)
     assert(addresses.any? { |ip| ip.is_a?(Resolv::IPv4) || ip.is_a?(Resolv::IPv6) })
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,6 @@ require "sparoid"
 
 require "minitest/stub_const"
 require "minitest/autorun"
+require "webmock/minitest"
+
+WebMock.allow_net_connect!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,5 +10,3 @@ require "sparoid"
 require "minitest/stub_const"
 require "minitest/autorun"
 require "webmock/minitest"
-
-WebMock.allow_net_connect!


### PR DESCRIPTION
## Problem

`Sparoid::Instance` memoized its public IP with `@public_ips ||= super`, which has two defects:

1. **Empty result pinned forever.** `[]` is truthy in Ruby, so once `@public_ips` is `[]` the `||=` short-circuits and never re-resolves. A single transient empty resolution (icanhazip down or returning an empty body) poisons the instance for its whole life — every later knock then builds zero messages and `auth` sends **zero SPA packets**.
2. **Non-atomic race / thundering herd.** `||=` is read-modify-write. When one `Instance` is shared across a thread pool, the first wave of knocks all resolve concurrently (a herd of icanhazip requests) and one slow/empty response clobbers a good value via last-writer-wins — then defect \#1 pins it.

This was caught in production (ssh-monitor worker.26, 2026-06-26): a dyno sent zero-packet knocks for its whole lifetime and alarmed every host as SSH-down. ssh-monitor currently carries an app-side monkey-patch for this; this PR moves the proper fix into the gem.

## Fix

- Move the caching into `Instance#cached_public_ips` (calling the inherited raw `public_ips` fetch directly — no `super`, no `public_ips` override).
- Resolve behind a **per-instance mutex with a double-check** — kills the thundering herd and the last-writer-wins clobber; concurrent callers wait and reuse the freshly cached IP.
- Cache only a **non-empty** result (the stable egress IP, returned lock-free on the fast path); **never memoize empty**, so a transient failure self-heals on the next knock.
- **Close the silent-success hole:** `generate_messages` now raises when an empty public-IP resolution and no IPv6 fallback would otherwise produce no messages, instead of letting `auth` report success having sent nothing.
- The raise is a new **`Sparoid::PublicIPError`** — a sibling of `ResolvError` under `Error` (so existing `rescue Sparoid::Error` still catches it), letting callers distinguish "I can't resolve my own public IP" (a client-side failure affecting every host) from "the target host is unreachable." Notably it is **not** a `ResolvError`, so ssh-monitor's `rescue Sparoid::ResolvError` "machine deleted" no-op won't silently swallow it.

## Tests

- `test_instance_retries_and_recovers_instead_of_pinning_empty` — empty resolve is not memoized; recovers once icanhazip responds again (webmock).
- `test_auth_raises_when_no_public_ip_resolved` — `auth` raises `Sparoid::PublicIPError` rather than silently sending zero packets.
- Manual concurrency check: 40 threads on one instance → a single resolution (2 HTTP calls, not 80), all threads get the good IP.

Adds `webmock` as a dev dependency.

> [!NOTE]
> Version bump + CHANGELOG and the ssh-monitor cleanup are intentionally left to separate follow-up PRs. The follow-up can rescue `Sparoid::PublicIPError` specifically so an icanhazip outage doesn't mark every host as SSH-down.