### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.2.1] - 2026-06-30
+
+- Make Sparoid::Instance public-IP resolution thread-safe and empty-aware; raise Sparoid::PublicIPError when no public IP resolves (#25)
+
 ## [2.2.0] - 2026-05-06
 
 - Raise when sendmsg fails for every resolved address (#23)

--- a/lib/sparoid/version.rb
+++ b/lib/sparoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sparoid
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end


### PR DESCRIPTION
Bumps `Sparoid::VERSION` to 2.2.1 and adds the CHANGELOG entry for the thread-safe / empty-aware public-IP resolution fix (#25).

Once merged, tag `v2.2.1` to trigger the rubygems publish (`.github/workflows/release.yml`).

## Changelog

- Make Sparoid::Instance public-IP resolution thread-safe and empty-aware; raise Sparoid::PublicIPError when no public IP resolves (#25)